### PR TITLE
Исправление файла root.scss

### DIFF
--- a/src/blocks/card/_type/card_type_direction.scss
+++ b/src/blocks/card/_type/card_type_direction.scss
@@ -17,13 +17,14 @@
 
   &__title {
     @extend %mainTitleH3;
+    @extend %zeroSpaces;
   }
 
   &__subtitle {
     @extend %mainTextStyle;
-    margin-top: 20px;
+    margin: $marginCardTitleText 0 0;
     @media screen and (max-width: 1439px) {
-      margin-top: 10px;
+      margin-top: $marginCardTitleTextTablet;
     }
   }
 

--- a/src/blocks/card/_type/card_type_works.scss
+++ b/src/blocks/card/_type/card_type_works.scss
@@ -18,15 +18,6 @@
   grid-template-rows: minmax(min-content, max-content);
   background-color: $backgroundColor;
 
-  @media screen and (max-width: 1439px) {
-    gap: 20px;
-    grid-template-columns: repeat(1, 1fr);
-  }
-
-  @media screen and (max-width: 767px) {
-    grid-template-columns: repeat(1, 1fr);
-  }
-
   &__icon {
     width: 64px;
     height: 64px;
@@ -35,7 +26,6 @@
       width: 48px;
       height: 48px;
     }
-    // Этот код выдаёт ошибку при подключении модуля. Как будто бы scss не умеет работать с png картинками.
     &_driver {
       background-image: url("../icons/blue-driver.png");
       @extend %backgoundIcon;
@@ -51,18 +41,28 @@
   }
   &__title {
     @extend %mainTitleH3;
+    @extend %zeroSpaces;
   }
 
   &__subtitle {
     @extend %mainTextStyle;
-    margin-top: 20px;
+    margin: $marginCardTitleText 0 0;
     @media screen and (max-width: 1439px) {
-      margin-top: 10px;
+      margin-top: $marginCardTitleTextTablet;
     }
   }
 
   &__button {
     align-self: flex-end;
     justify-self: start;
+  }
+
+  @media screen and (max-width: 1439px) {
+    gap: 20px;
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  @media screen and (max-width: 767px) {
+    grid-template-columns: repeat(1, 1fr);
   }
 }

--- a/src/blocks/cards-container/cards-container.scss
+++ b/src/blocks/cards-container/cards-container.scss
@@ -3,31 +3,38 @@
 .cards-container {
   max-width: 1440px;
   @include grid;
+  list-style-type: none;
+  padding: 0;
+  margin: 0;
   &_type_works {
     grid-template-columns: repeat(3, 1fr);
-    list-style-type: none;
-    padding: 0;
-    margin: 50px 0 0;
+    margin: $marginTitleContent 0 0;
     @media screen and (max-width: 1439px) {
-      margin-top: 32px;
+      margin-top: $marginTitleContentTablet;
       grid-template-columns: repeat(1, 1fr);
     }
     @media screen and (max-width: 900px) {
       max-width: 450px;
     }
     @media screen and (max-width: 767px) {
-      margin-top: 24px;
+      margin-top: $marginTitleContentMobile;
       max-width: none;
     }
   }
   
   &_type_directions {
+    grid-template-columns: repeat(3, 1fr);
+    margin: $marginTitleContent 0 0;
+    padding: 0 $paddingSectionHorizontal;
     @media screen and (max-width: 1439px) {
+      margin-top: $marginTitleContentTablet;
       grid-template-columns: repeat(2, 1fr);
       max-width: none;
     }
     @media screen and (max-width: 767px) {
+      margin-top: $marginTitleContentMobile;
       grid-template-columns: repeat(1, 1fr);
+      padding: 0 $paddingSectionHorizontalMobile;
     }
   }
 }

--- a/src/blocks/content/content.scss
+++ b/src/blocks/content/content.scss
@@ -1,4 +1,3 @@
 .content {
-  @include flex(column, center, center);
   width: 100%;
 }

--- a/src/blocks/digits/digits.scss
+++ b/src/blocks/digits/digits.scss
@@ -1,6 +1,7 @@
 .digits {
   @extend %limitedWidthSection;
   padding: $marginBlocks $paddingSectionHorizontal 0;
+  margin: 0 auto;
 
   &__container {
     box-sizing: border-box;
@@ -11,6 +12,7 @@
 
   &__title {
     @extend %mainTitleH2;
+    @extend %zeroSpaces;
   }
 
   &__image-container {
@@ -56,6 +58,7 @@
 
   &__item-text {
     @extend %mainTextStyle;
+    @extend %zeroSpaces;
   }
 }
 

--- a/src/blocks/directions/directions.scss
+++ b/src/blocks/directions/directions.scss
@@ -2,14 +2,19 @@
 
 .directions {
   @include flex(column, center, center);
-  padding: 100px 0;
+  padding: $paddingSectionVertical 0;
   &__title {
     @extend %mainTitleH2;
+    @extend %zeroSpaces;
+    padding: 0 $paddingSectionHorizontal;
+    @media screen and (max-width: 767px) {
+      padding: 0 $paddingSectionHorizontalMobile;
+    }
   }
   @media screen and (max-width: 1439px) {
-    padding: 50px 0;
+    padding: $paddingSectionVerticalTablet 0;
   }
   @media screen and (max-width: 767px) {
-    padding: 32px 0;
+    padding: $paddingSectionVerticalMobile 0;
   }
 }

--- a/src/blocks/menu/menu.scss
+++ b/src/blocks/menu/menu.scss
@@ -1,5 +1,6 @@
 .menu {
   @extend %limitedWidthSection;
+  margin: 0 auto;
   padding: 0px 42px 0px;
   height: 50px;
 

--- a/src/blocks/root.scss
+++ b/src/blocks/root.scss
@@ -106,6 +106,9 @@ $purplePressed: #4935B5;
 @mixin raleway {
   font-family: $fontFamily;
   line-height: 120%;
+}
+
+%zeroSpaces {
   margin: 0;
   padding: 0;
 }

--- a/src/blocks/works/works.scss
+++ b/src/blocks/works/works.scss
@@ -2,15 +2,16 @@
 
 .works {
   @include flex(column, center, center);
-  padding: 100px 0;
+  padding: $paddingSectionVertical 0;
   background-color: $lightGrey;
   &__title {
     @extend %mainTitleH2;
+    @extend %zeroSpaces;
   }
   @media screen and (max-width: 1439px) {
-    padding: 50px 0;
+    padding: $paddingSectionVerticalTablet 0;
   }
   @media screen and (max-width: 767px) {
-    padding: 32px 0;
+    padding: $paddingSectionVerticalMobile 0;
   }
 }

--- a/src/blocks/wrapper/wrapper.scss
+++ b/src/blocks/wrapper/wrapper.scss
@@ -3,8 +3,11 @@
 .wrapper {
   max-width: 1440px;
   box-sizing: border-box;
-  padding: 0 40px;
-  @media screen and (max-width: 767px) {
-    padding: 0 10px;
+  
+  &_type_grey {
+    padding: 0 $paddingSectionHorizontal;
+    @media screen and (max-width: 767px) {
+      padding: 0 $paddingSectionHorizontalMobile;
+    }
   }
 }

--- a/src/index.html
+++ b/src/index.html
@@ -43,7 +43,7 @@
       <form class="donation-checkbox"></form>
     </section>
     <section class="works">
-      <div class="wrapper">
+      <div class="wrapper wrapper_type_grey">
         <h2 class="works__title">Для кого мы работаем</h2>
         <ul class="cards-container cards-container_type_works">
           <li class="card card_type_works">


### PR DESCRIPTION
Список изменений:
1) Создана новая система отступов. Теперь к каждому отступу добавляется слово в названии **Tablet** или **Mobile**. Каждую переменную нужно будет использовать в своём медиа запросе.
2) Удалён стиль `@include flex(......)` из файла `content.scss` так как он портил задний фон у секций с серым цветом.
3) Отредактированы файлы **menu.scss** и **digits.scss** в них добавлено `margin: 0 auto;` чтобы контент выравнивался по центру.
4) В файле **root.scss** создан дополнительный шаблон `%zeroSpaces`. Он был необходим, так как не давал исправлять свойства `margin` и `padding` внутри шаблонов с типографикой. **Теперь нужно задавать margin и padding для всех текстовых элементов.**
Принцип работы:
   а) Если менять свойства `margin` и `padding` не нужно, используйте `@extend %zeroSpaces`.
   б) Если менять свойства `margin` и `padding` нужно, то лучше их прописать внутри стиля и поменять в меди запросах.
5) Добавлены исправления во все секции, чтобы выравнивать контент и убирать отступы, где они не нужны.
6) Исправлен файл **wrapper.scss**. Стиль wrapper теперь только ограничивает контент внутри секции. Для цветовых секций, есть стиль на отступы. Применяй его если тебе нужны отступы внутри окрашенных в другой цвет секций.